### PR TITLE
Fix renaming from initial value

### DIFF
--- a/MemoryMarker/Windows/RenameWindow.cs
+++ b/MemoryMarker/Windows/RenameWindow.cs
@@ -48,7 +48,8 @@ public unsafe class RenameWindow : Window
 
         if (setting.Name == string.Empty)
         {
-            setting.Name = AgentFieldMarker->PresetLabelsSpan[slotIndex].ToString().Split(" ")[1];
+            var name = AgentFieldMarker->PresetLabelsSpan[slotIndex].ToString();
+            setting.Name = name[(name.IndexOf(' ') + 1)..];
         }
         
         ImGuiHelpers.ScaledDummy(10.0f);


### PR DESCRIPTION
o/ hope you don't mind a small random PR to fix something that was bugging me: previously, hitting Rename on a slot with no custom name would populate the popup with just the first word of the default name (so if the slot was labelled "The Arm of the Father" or whatever immediately after saving it, the rename popup would just be prefilled with "The"). Now it includes the entire default name (apart from the number at the start, which is still excluded).